### PR TITLE
Add committer stats to audit user_owners

### DIFF
--- a/app/controllers/audit_controller.rb
+++ b/app/controllers/audit_controller.rb
@@ -6,7 +6,8 @@ class AuditController < ApplicationController
   end
 
   def user_owners
-    @collectives = Collective.opensource.with_user_owner.order('transactions_count desc nulls last')
+    @collectives = Collective.opensource.with_user_owner.order('transactions_count desc nulls last').to_a
+    Collective.preload_commit_stats(@collectives)
   end
 
   def no_projects

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -115,6 +115,24 @@ class Collective < ApplicationRecord
 
   BOT_LOGIN_PATTERNS = [/\[bot\]$/i, /\Adependabot/i, /\Arenovate/i, /\Agreenkeeper/i, /-bot\z/i].freeze
 
+  attr_writer :project_commit_stats
+
+  def self.preload_commit_stats(collectives)
+    by_collective = Project.source
+      .where(collective_id: collectives.map(&:id))
+      .where.not(commit_stats: nil)
+      .pluck(:collective_id, :commit_stats)
+      .group_by(&:first)
+    collectives.each do |c|
+      c.project_commit_stats = (by_collective[c.id] || []).map(&:last)
+    end
+    collectives
+  end
+
+  def project_commit_stats
+    @project_commit_stats ||= projects.source.where.not(commit_stats: nil).pluck(:commit_stats)
+  end
+
   def bot_committer?(committer)
     login = committer['login'].to_s
     name = committer['name'].to_s
@@ -124,7 +142,7 @@ class Collective < ApplicationRecord
   def past_year_committers
     return @past_year_committers if defined?(@past_year_committers)
     merged = {}
-    projects.source.where.not(commit_stats: nil).pluck(:commit_stats).each do |stats|
+    project_commit_stats.each do |stats|
       Array(stats['past_year_committers']).each do |c|
         next if bot_committer?(c)
         key = (c['login'].presence || c['email'].presence || c['name']).to_s.downcase
@@ -163,8 +181,9 @@ class Collective < ApplicationRecord
 
   def owner_commit_share
     total = past_year_total_human_commits
-    return nil if total.zero? || past_year_owner_commits.nil?
-    (past_year_owner_commits.to_f / total * 100).round(1)
+    owner_commits = past_year_owner_commits
+    return nil if total.zero? || owner_commits.nil?
+    (owner_commits.to_f / total * 100).round(1)
   end
 
   def solo_maintainer?

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -113,6 +113,65 @@ class Collective < ApplicationRecord
     last_project_activity_at < 1.year.ago
   end
 
+  BOT_LOGIN_PATTERNS = [/\[bot\]$/i, /\Adependabot/i, /\Arenovate/i, /\Agreenkeeper/i, /-bot\z/i].freeze
+
+  def bot_committer?(committer)
+    login = committer['login'].to_s
+    name = committer['name'].to_s
+    BOT_LOGIN_PATTERNS.any? { |p| login.match?(p) || name.match?(p) }
+  end
+
+  def past_year_committers
+    return @past_year_committers if defined?(@past_year_committers)
+    merged = {}
+    projects.source.where.not(commit_stats: nil).pluck(:commit_stats).each do |stats|
+      Array(stats['past_year_committers']).each do |c|
+        next if bot_committer?(c)
+        key = (c['login'].presence || c['email'].presence || c['name']).to_s.downcase
+        merged[key] ||= { 'login' => c['login'], 'name' => c['name'], 'email' => c['email'], 'count' => 0 }
+        merged[key]['count'] += c['count'].to_i
+      end
+    end
+    @past_year_committers = merged.values.sort_by { |c| -c['count'] }
+  end
+
+  def past_year_committers_count
+    past_year_committers.length
+  end
+
+  def owner_login
+    owner.try(:[], 'login')
+  end
+
+  def past_year_other_committers
+    return past_year_committers if owner_login.blank?
+    past_year_committers.reject { |c| c['login'].to_s.casecmp?(owner_login) }
+  end
+
+  def past_year_other_committers_count
+    past_year_other_committers.length
+  end
+
+  def past_year_owner_commits
+    return nil if owner_login.blank?
+    past_year_committers.find { |c| c['login'].to_s.casecmp?(owner_login) }.try(:[], 'count').to_i
+  end
+
+  def past_year_total_human_commits
+    past_year_committers.sum { |c| c['count'] }
+  end
+
+  def owner_commit_share
+    total = past_year_total_human_commits
+    return nil if total.zero? || past_year_owner_commits.nil?
+    (past_year_owner_commits.to_f / total * 100).round(1)
+  end
+
+  def solo_maintainer?
+    return nil if past_year_committers.empty?
+    past_year_other_committers_count.zero?
+  end
+
   def org_owner?
     return false if owner.nil?
     owner['kind'] == 'organization'

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -407,8 +407,7 @@ class Project < ApplicationRecord
     "https://commits.ecosyste.ms/api/v1/repositories/lookup?url=#{repository_url}"
   end
 
-  def sync_commits
-    return unless repository.present?
+  def fetch_commit_stats
     conn = Faraday.new(url: commits_api_url) do |faraday|
       faraday.response :follow_redirects
       faraday.headers['User-Agent'] = 'opencollective.ecosyste.ms'
@@ -416,7 +415,19 @@ class Project < ApplicationRecord
     end
     response = conn.get
     return unless response.success?
-    commits_list_url = JSON.parse(response.body)['commits_url'] + '?per_page=100'
+    json = JSON.parse(response.body)
+    update_columns(commit_stats: json.except('commits_url', 'repository_url', 'host', 'created_at', 'updated_at'))
+    json
+  rescue
+    puts "Error fetching commit stats for #{repository_url}"
+    nil
+  end
+
+  def sync_commits
+    return unless repository.present?
+    json = fetch_commit_stats
+    return unless json.present?
+    commits_list_url = json['commits_url'] + '?per_page=100'
 
     page = 1
     loop do

--- a/app/views/audit/user_owners.csv.erb
+++ b/app/views/audit/user_owners.csv.erb
@@ -1,5 +1,5 @@
-<%- headers = ['slug', 'owner', 'kind', 'url','repositories_count'] -%>
+<%- headers = ['slug', 'owner', 'kind', 'url', 'repositories_count', 'last_activity_at', 'past_year_committers', 'past_year_other_committers', 'owner_commit_share_pct', 'solo_maintainer', 'top_committers'] -%>
 <%= CSV.generate_line headers -%>
 <%- @collectives.each do |collective| -%>
-<%= CSV.generate_line([collective.slug, collective.owner['login'], collective.owner['kind'], collective.owner['html_url'], collective.owner['repositories_count']]) -%>
+<%= CSV.generate_line([collective.slug, collective.owner['login'], collective.owner['kind'], collective.owner['html_url'], collective.owner['repositories_count'], collective.last_project_activity_at&.to_date, collective.past_year_committers_count, collective.past_year_other_committers_count, collective.owner_commit_share, collective.solo_maintainer?, collective.past_year_committers.first(5).map { |c| "#{c['login'] || c['name']}:#{c['count']}" }.join(' ')]) -%>
 <%- end -%>

--- a/app/views/audit/user_owners.html.erb
+++ b/app/views/audit/user_owners.html.erb
@@ -14,6 +14,17 @@
             <p><%= collective.description %></p>
             <p><%= number_with_delimiter collective.projects_count %> repositories - <%= number_with_delimiter collective.transactions_count %> transactions - Balance: <%= collective.balance.round(2)%> <%= collective.currency %></p>
             <p>Owner: <%= link_to collective.owner['login'], collective.owner['html_url'], target: :_blank %></p>
+            <p>
+              Last activity: <%= collective.last_project_activity_at&.to_date || 'unknown' %>
+              - Past year committers: <%= collective.past_year_committers_count %>
+              (<%= collective.past_year_other_committers_count %> besides owner)
+              <% if collective.owner_commit_share %>
+                - Owner share: <%= collective.owner_commit_share %>%
+              <% end %>
+              <% if collective.solo_maintainer? %>
+                <span class="badge bg-warning text-dark">solo</span>
+              <% end %>
+            </p>
           </div>
           <div class="flex-shrink-0">
             <img src="<%= collective.icon_url %>" class="rounded" height='40' width='40' onerror="this.style.display='none'">

--- a/db/migrate/20260624140201_add_commit_stats_to_projects.rb
+++ b/db/migrate/20260624140201_add_commit_stats_to_projects.rb
@@ -1,0 +1,5 @@
+class AddCommitStatsToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :commit_stats, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,165 +10,166 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_08_165100) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_24_140201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
 
   create_table "advisories", force: :cascade do |t|
-    t.integer "project_id"
-    t.string "uuid"
-    t.string "url"
-    t.string "title"
-    t.text "description"
-    t.string "origin"
-    t.string "severity"
-    t.datetime "published_at"
-    t.datetime "withdrawn_at"
+    t.float "blast_radius"
     t.string "classification"
+    t.datetime "created_at", null: false
     t.float "cvss_score"
     t.string "cvss_vector"
-    t.string "references", default: [], array: true
-    t.string "source_kind"
+    t.text "description"
     t.string "identifiers", default: [], array: true
+    t.string "origin"
     t.jsonb "packages", default: []
+    t.integer "project_id"
+    t.datetime "published_at"
+    t.string "references", default: [], array: true
     t.string "repository_url"
-    t.datetime "created_at", null: false
+    t.string "severity"
+    t.string "source_kind"
+    t.string "title"
     t.datetime "updated_at", null: false
-    t.float "blast_radius"
+    t.string "url"
+    t.string "uuid"
+    t.datetime "withdrawn_at"
     t.index ["project_id"], name: "index_advisories_on_project_id"
   end
 
   create_table "collectives", force: :cascade do |t|
-    t.string "uuid"
-    t.string "slug"
-    t.string "name"
-    t.string "description"
-    t.string "tags", default: [], array: true
-    t.string "website"
-    t.string "github"
-    t.string "twitter"
-    t.string "repository_url"
-    t.json "social_links"
-    t.string "currency"
-    t.integer "projects_count"
-    t.datetime "last_synced_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "transactions_count"
-    t.float "balance"
     t.string "account_type"
-    t.json "owner"
-    t.datetime "last_project_activity_at"
     t.boolean "archived"
-    t.boolean "no_funding"
-    t.boolean "no_license"
-    t.string "host"
+    t.float "balance"
     t.datetime "collective_created_at"
     t.datetime "collective_updated_at"
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.string "description"
+    t.string "github"
+    t.string "host"
+    t.datetime "last_project_activity_at"
+    t.datetime "last_synced_at"
+    t.string "name"
+    t.boolean "no_funding"
+    t.boolean "no_license"
+    t.json "owner"
+    t.integer "projects_count"
+    t.string "repository_url"
+    t.string "slug"
+    t.json "social_links"
+    t.string "tags", default: [], array: true
     t.float "total_donations"
+    t.integer "transactions_count"
+    t.string "twitter"
+    t.datetime "updated_at", null: false
+    t.string "uuid"
+    t.string "website"
     t.index ["account_type"], name: "index_collectives_on_account_type"
     t.index ["host"], name: "index_collectives_on_host"
     t.index ["slug"], name: "index_collectives_on_slug", unique: true
   end
 
   create_table "commits", force: :cascade do |t|
-    t.integer "project_id", null: false
-    t.string "sha"
-    t.string "message"
-    t.datetime "timestamp"
-    t.boolean "merge"
+    t.integer "additions"
     t.string "author"
     t.string "committer"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "additions"
     t.integer "deletions"
     t.integer "files_changed"
+    t.boolean "merge"
+    t.string "message"
+    t.integer "project_id", null: false
+    t.string "sha"
+    t.datetime "timestamp"
+    t.datetime "updated_at", null: false
     t.index ["project_id", "timestamp"], name: "index_commits_on_project_id_and_timestamp"
   end
 
   create_table "issues", force: :cascade do |t|
-    t.integer "project_id"
-    t.string "uuid"
-    t.string "node_id"
-    t.integer "number"
-    t.string "state"
-    t.string "title"
-    t.string "body"
-    t.string "user"
     t.string "assignees"
-    t.boolean "locked"
-    t.integer "comments_count"
-    t.boolean "pull_request"
+    t.string "author_association"
+    t.string "body"
     t.datetime "closed_at"
     t.string "closed_by"
-    t.string "author_association"
-    t.string "state_reason"
-    t.integer "time_to_close"
-    t.datetime "merged_at"
+    t.integer "comments_count"
+    t.datetime "created_at", null: false
     t.json "dependency_metadata"
     t.string "html_url"
-    t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "labels", default: [], array: true
+    t.boolean "locked"
+    t.datetime "merged_at"
+    t.string "node_id"
+    t.integer "number"
+    t.integer "project_id"
+    t.boolean "pull_request"
+    t.string "state"
+    t.string "state_reason"
+    t.integer "time_to_close"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.string "url"
+    t.string "user"
+    t.string "uuid"
     t.index ["project_id", "pull_request", "closed_at"], name: "index_issues_on_project_id_and_pull_request_and_closed_at"
     t.index ["project_id", "pull_request", "created_at"], name: "index_issues_on_project_id_and_pull_request_and_created_at"
     t.index ["project_id", "pull_request", "user"], name: "index_issues_on_project_id_and_pull_request_and_user"
   end
 
   create_table "packages", force: :cascade do |t|
-    t.integer "project_id", null: false
-    t.string "name"
-    t.string "ecosystem"
-    t.string "purl"
-    t.json "metadata"
     t.datetime "created_at", null: false
+    t.string "ecosystem"
+    t.json "metadata"
+    t.string "name"
+    t.integer "project_id", null: false
+    t.string "purl"
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_packages_on_project_id"
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string "url"
-    t.json "repository"
+    t.integer "collective_id"
+    t.json "commit_stats"
+    t.datetime "created_at", null: false
+    t.integer "issues_count", default: 0
     t.string "keywords", default: [], array: true
     t.datetime "last_synced_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "issues_count", default: 0
-    t.text "readme"
-    t.integer "collective_id"
     t.integer "packages_count"
+    t.text "readme"
+    t.json "repository"
+    t.datetime "updated_at", null: false
+    t.string "url"
     t.index ["collective_id"], name: "index_projects_on_collective_id"
     t.index ["url"], name: "index_projects_on_url", unique: true
   end
 
   create_table "tags", force: :cascade do |t|
-    t.integer "project_id", null: false
-    t.string "name"
-    t.string "sha"
-    t.string "kind"
-    t.datetime "published_at"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "html_url"
+    t.string "kind"
+    t.string "name"
+    t.integer "project_id", null: false
+    t.datetime "published_at"
+    t.string "sha"
+    t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_tags_on_project_id"
   end
 
   create_table "transactions", force: :cascade do |t|
-    t.integer "collective_id"
-    t.string "uuid"
-    t.float "amount"
-    t.float "net_amount"
-    t.string "transaction_type"
-    t.string "currency"
     t.string "account"
-    t.string "description"
+    t.float "amount"
+    t.integer "collective_id"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "transaction_kind"
+    t.string "currency"
+    t.string "description"
+    t.float "net_amount"
     t.string "transaction_expense_type"
+    t.string "transaction_kind"
+    t.string "transaction_type"
+    t.datetime "updated_at", null: false
+    t.string "uuid"
     t.index ["collective_id", "transaction_type", "created_at"], name: "idx_on_collective_id_transaction_type_created_at_e56e46ac84"
     t.index ["collective_id", "updated_at"], name: "index_transactions_on_collective_id_and_updated_at"
     t.index ["uuid"], name: "index_transactions_on_uuid", unique: true

--- a/lib/tasks/collectives.rake
+++ b/lib/tasks/collectives.rake
@@ -18,4 +18,17 @@ namespace :collectives do
   task sync_funders: :environment do
     Collective.sync_funders
   end
+
+  desc 'fetch commit stats for user-owner collectives'
+  task fetch_user_owner_commit_stats: :environment do
+    scope = Project.where(collective_id: Collective.opensource.with_user_owner.select(:id))
+                   .source
+                   .where(commit_stats: nil)
+    total = scope.count
+    puts "Fetching commit stats for #{total} projects"
+    scope.find_each.with_index do |project, i|
+      project.fetch_commit_stats
+      puts "#{i + 1}/#{total}" if (i + 1) % 100 == 0
+    end
+  end
 end

--- a/test/controllers/audit_controller_test.rb
+++ b/test/controllers/audit_controller_test.rb
@@ -62,6 +62,23 @@ class AuditControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes result.map(&:id), collective_without_repo.id
   end
 
+  test 'user_owners renders with commit stats' do
+    collective = Collective.create!(slug: 'solo', host: 'opensource', balance: 0, currency: 'USD',
+      owner: { 'kind' => 'user', 'login' => 'alice', 'html_url' => 'https://github.com/alice', 'repositories_count' => 1 })
+    collective.projects.create!(url: 'https://github.com/alice/thing', repository: { 'fork' => false },
+      commit_stats: { 'past_year_committers' => [{ 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 50 }] })
+
+    get '/audit/user_owners'
+    assert_response :success
+    assert_match 'solo', response.body
+
+    get '/audit/user_owners.csv'
+    assert_response :success
+    assert_match 'solo_maintainer', response.body
+    assert_match 'solo,alice', response.body
+    assert_match 'true', response.body
+  end
+
   test 'duplicates optimized query matches current logic' do
     collective1 = Collective.create!(slug: 'test-dup-1', repository_url: 'https://github.com/test/repo', host: 'opensource')
     collective2 = Collective.create!(slug: 'test-dup-2', repository_url: 'https://github.com/TEST/REPO', host: 'opensource')

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -7,7 +7,104 @@ class CollectiveTest < ActiveSupport::TestCase
     collective.social_links = [{"type"=>"WEBSITE", "url"=>"https://github.com/Chinachu/Chinachu"},
     {"type"=>"TWITTER", "url"=>"https://twitter.com/chinachu_rec"},
     {"type"=>"GITHUB", "url"=>"https://github.com/Chinachu"}]
-  
+
     assert_equal 'https://github.com/Chinachu/Chinachu', collective.project_url
+  end
+
+  def build_collective_with_stats(owner_login:, stats:)
+    collective = Collective.create!(slug: "test-#{SecureRandom.hex(4)}", host: 'opensource', owner: { 'kind' => 'user', 'login' => owner_login })
+    stats.each_with_index do |s, i|
+      collective.projects.create!(url: "https://github.com/#{owner_login}/repo#{i}", repository: { 'fork' => false }, commit_stats: s)
+    end
+    collective
+  end
+
+  test "past_year_committers merges across projects, drops bots, sums counts" do
+    stats1 = { 'past_year_committers' => [
+      { 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 10 },
+      { 'name' => 'dependabot[bot]', 'email' => 'd@x', 'login' => 'dependabot[bot]', 'count' => 5 }
+    ] }
+    stats2 = { 'past_year_committers' => [
+      { 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 3 },
+      { 'name' => 'Bob', 'email' => 'b@x', 'login' => 'bob', 'count' => 7 }
+    ] }
+    collective = build_collective_with_stats(owner_login: 'alice', stats: [stats1, stats2])
+
+    committers = collective.past_year_committers
+    assert_equal 2, committers.length
+    assert_equal 'alice', committers.first['login']
+    assert_equal 13, committers.first['count']
+    assert_equal 'bob', committers.last['login']
+  end
+
+  test "past_year_other_committers excludes owner login case-insensitively" do
+    stats = { 'past_year_committers' => [
+      { 'name' => 'Alice', 'email' => 'a@x', 'login' => 'Alice', 'count' => 10 },
+      { 'name' => 'Bob', 'email' => 'b@x', 'login' => 'bob', 'count' => 2 }
+    ] }
+    collective = build_collective_with_stats(owner_login: 'alice', stats: [stats])
+
+    assert_equal 1, collective.past_year_other_committers_count
+    assert_equal 'bob', collective.past_year_other_committers.first['login']
+  end
+
+  test "owner_commit_share" do
+    stats = { 'past_year_committers' => [
+      { 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 90 },
+      { 'name' => 'Bob', 'email' => 'b@x', 'login' => 'bob', 'count' => 10 }
+    ] }
+    collective = build_collective_with_stats(owner_login: 'alice', stats: [stats])
+
+    assert_equal 90.0, collective.owner_commit_share
+  end
+
+  test "owner_commit_share is nil with no commit data" do
+    collective = build_collective_with_stats(owner_login: 'alice', stats: [{ 'past_year_committers' => [] }])
+    assert_nil collective.owner_commit_share
+  end
+
+  test "solo_maintainer? true when only owner committed" do
+    stats = { 'past_year_committers' => [
+      { 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 50 },
+      { 'name' => 'renovate[bot]', 'email' => 'r@x', 'login' => 'renovate[bot]', 'count' => 20 }
+    ] }
+    collective = build_collective_with_stats(owner_login: 'alice', stats: [stats])
+
+    assert_equal true, collective.solo_maintainer?
+  end
+
+  test "solo_maintainer? false when another human committed" do
+    stats = { 'past_year_committers' => [
+      { 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 50 },
+      { 'name' => 'Bob', 'email' => 'b@x', 'login' => 'bob', 'count' => 1 }
+    ] }
+    collective = build_collective_with_stats(owner_login: 'alice', stats: [stats])
+
+    assert_equal false, collective.solo_maintainer?
+  end
+
+  test "solo_maintainer? nil when no commit stats" do
+    collective = Collective.create!(slug: 'no-stats', host: 'opensource', owner: { 'kind' => 'user', 'login' => 'alice' })
+    assert_nil collective.solo_maintainer?
+  end
+
+  test "past_year_committers ignores forks" do
+    collective = Collective.create!(slug: 'forky', host: 'opensource', owner: { 'kind' => 'user', 'login' => 'alice' })
+    collective.projects.create!(url: 'https://github.com/alice/source', repository: { 'fork' => false },
+      commit_stats: { 'past_year_committers' => [{ 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 5 }] })
+    collective.projects.create!(url: 'https://github.com/alice/fork', repository: { 'fork' => true },
+      commit_stats: { 'past_year_committers' => [{ 'name' => 'Upstream', 'email' => 'u@x', 'login' => 'upstream', 'count' => 999 }] })
+
+    assert_equal 1, collective.past_year_committers_count
+    assert_equal 'alice', collective.past_year_committers.first['login']
+  end
+
+  test "committer with no login dedupes by email" do
+    stats1 = { 'past_year_committers' => [{ 'name' => 'Anon', 'email' => 'anon@x', 'login' => nil, 'count' => 4 }] }
+    stats2 = { 'past_year_committers' => [{ 'name' => 'Anon Different', 'email' => 'anon@x', 'login' => nil, 'count' => 6 }] }
+    collective = build_collective_with_stats(owner_login: 'alice', stats: [stats1, stats2])
+
+    assert_equal 1, collective.past_year_committers_count
+    assert_equal 10, collective.past_year_committers.first['count']
   end
 end

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -99,6 +99,26 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_equal 'alice', collective.past_year_committers.first['login']
   end
 
+  test "preload_commit_stats avoids per-collective queries" do
+    c1 = build_collective_with_stats(owner_login: 'alice', stats: [{ 'past_year_committers' => [{ 'login' => 'alice', 'name' => 'Alice', 'email' => 'a@x', 'count' => 5 }] }])
+    c2 = build_collective_with_stats(owner_login: 'bob', stats: [{ 'past_year_committers' => [{ 'login' => 'bob', 'name' => 'Bob', 'email' => 'b@x', 'count' => 3 }] }])
+
+    collectives = Collective.where(id: [c1.id, c2.id]).to_a
+    Collective.preload_commit_stats(collectives)
+
+    assert_no_queries do
+      assert_equal 1, collectives.first.past_year_committers_count
+      assert_equal 1, collectives.last.past_year_committers_count
+    end
+  end
+
+  def assert_no_queries(&block)
+    count = 0
+    counter = ->(*) { count += 1 }
+    ActiveSupport::Notifications.subscribed(counter, 'sql.active_record', &block)
+    assert_equal 0, count, "Expected no queries, got #{count}"
+  end
+
   test "committer with no login dedupes by email" do
     stats1 = { 'past_year_committers' => [{ 'name' => 'Anon', 'email' => 'anon@x', 'login' => nil, 'count' => 4 }] }
     stats2 = { 'past_year_committers' => [{ 'name' => 'Anon Different', 'email' => 'anon@x', 'login' => nil, 'count' => 6 }] }

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -13,6 +13,42 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 'https://github.com/foo/bar', repo_url
   end
 
+  test "fetch_commit_stats stores summary json" do
+    collective = Collective.create!(slug: 'test-stats', host: 'opensource')
+    project = Project.create!(url: 'https://github.com/foo/bar', collective: collective)
+
+    body = {
+      'total_commits' => 100,
+      'past_year_total_committers' => 3,
+      'past_year_committers' => [{ 'name' => 'Alice', 'email' => 'a@x', 'login' => 'alice', 'count' => 90 }],
+      'commits_url' => 'https://commits.ecosyste.ms/api/v1/hosts/GitHub/repositories/foo%2Fbar/commits',
+      'host' => { 'name' => 'GitHub' },
+      'created_at' => '2024-01-01T00:00:00Z',
+      'updated_at' => '2026-01-01T00:00:00Z'
+    }
+    stub_request(:get, "https://commits.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/foo/bar")
+      .to_return(status: 200, body: body.to_json)
+
+    project.fetch_commit_stats
+    project.reload
+
+    assert_equal 100, project.commit_stats['total_commits']
+    assert_equal 'alice', project.commit_stats['past_year_committers'].first['login']
+    assert_nil project.commit_stats['commits_url']
+    assert_nil project.commit_stats['host']
+  end
+
+  test "fetch_commit_stats handles 404" do
+    collective = Collective.create!(slug: 'test-stats-404', host: 'opensource')
+    project = Project.create!(url: 'https://github.com/foo/missing', collective: collective)
+
+    stub_request(:get, "https://commits.ecosyste.ms/api/v1/repositories/lookup?url=https://github.com/foo/missing")
+      .to_return(status: 404)
+
+    assert_nil project.fetch_commit_stats
+    assert_nil project.reload.commit_stats
+  end
+
   test "handles nil packages_count" do
     collective = Collective.create!(slug: 'test-collective', host: 'opensource')
     project = Project.create!(url: 'https://github.com/test/repo', collective: collective)


### PR DESCRIPTION
OC staff want to know, for each user-owned collective, when the repo was last active, whether anyone besides the owner has committed in the last 12 months, roughly how many other contributors there are, and how concentrated commits are on the owner.

The commits.ecosyste.ms repo lookup already computes all of this, including resolved GitHub logins per committer and a past-year window. We were fetching that response in `sync_commits` but only reading `commits_url` from it.

This adds a `commit_stats` json column to `projects` and a `Project#fetch_commit_stats` method that stores the summary. `sync_commits` now uses it instead of duplicating the request.

`Collective` gains `past_year_committers` (merged across non-fork projects, deduped by login/email, bots filtered), `past_year_other_committers_count`, `owner_commit_share`, and `solo_maintainer?`.

The `/audit/user_owners` page and CSV export now include last activity date, past-year committer counts, owner commit share %, a solo flag, and the top 5 committers as `login:count`.

`rake collectives:fetch_user_owner_commit_stats` backfills the ~5.6k non-fork projects under user-owner collectives. It skips already-populated projects so it's resumable.