### PR TITLE
Disable sessions and add cache headers so CDN can cache HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,18 @@
 class ApplicationController < ActionController::Base
   skip_forgery_protection
+  before_action { request.session_options[:skip] = true }
   include Pagy::Backend
 
   rescue_from Pagy::OverflowError do
     head :not_found
+  end
+
+  before_action :set_cache_headers
+
+  def set_cache_headers
+    return unless request.get? || request.head?
+    expires_in 5.minutes, public: true, stale_while_revalidate: 1.hour
+    response.cache_control[:extras] = ["s-maxage=#{6.hours.to_i}"]
   end
 
   def default_url_options(options = {})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
       <%= meta_title %>
     </title>
     <meta name="description" content="<%= meta_description %>">
-    <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,9 @@ module OpenCollective
     config.load_defaults 7.0
     config.exceptions_app = routes
     config.active_support.to_time_preserves_timezone = :zone
+
+    config.session_store :disabled
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::Cookies
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require 'sidekiq/web'
 require 'sidekiq-status/web'
 
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_opencollective_sidekiq_session', path: '/sidekiq'
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ require 'sidekiq/web'
 require 'sidekiq-status/web'
 
 Sidekiq::Web.use ActionDispatch::Cookies
-Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_opencollective_sidekiq_session', path: '/sidekiq'
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_opencollective_sidekiq_session', path: '/sidekiq', secure: Rails.env.production?
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class CacheHeadersTest < ActionDispatch::IntegrationTest
+  test 'html pages set public cache headers with s-maxage' do
+    get '/funders'
+    assert_response :success
+    cache_control = response.headers['Cache-Control']
+    assert_match(/public/, cache_control)
+    assert_match(/max-age=300/, cache_control)
+    assert_match(/s-maxage=21600/, cache_control)
+  end
+
+  test 'html pages do not set cookies' do
+    get '/funders'
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test 'collective show does not set cookies' do
+    collective = Collective.create!(slug: 'cookie-test', host: 'opensource')
+    get collective_path(collective)
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+end


### PR DESCRIPTION
`csrf_meta_tags` in the layout writes `_csrf_token` to the session on every render, which forces a `Set-Cookie: _open_collective_session=...` header on every response. Cloudflare (with origin cache control) returns `cf-cache-status: BYPASS` for responses carrying `Set-Cookie`, and APISIX `proxy-cache` never stores them:

```
$ curl -sI https://opencollective.ecosyste.ms/
set-cookie: _open_collective_session=...
apisix-cache-status: EXPIRED
cf-cache-status: BYPASS
```

This app also had no `expires_in`/`s-maxage` on responses (only `fresh_when` etags), so add a `set_cache_headers` before_action matching commits/sponsors: `public, max-age=300, s-maxage=21600, stale-while-revalidate=3600`.

There's no login on this app and forgery protection was already skipped, so:

- `config.session_store :disabled` and remove `ActionDispatch::Cookies` / `Session::CookieStore` from the middleware stack
- drop `csrf_meta_tags` from the layout
- `request.session_options[:skip] = true` in `ApplicationController`
- add `set_cache_headers` before_action
- give `Sidekiq::Web` its own session middleware scoped to `/sidekiq` so retry/delete buttons keep working behind basic auth
- tests asserting cache headers and no `Set-Cookie` on HTML responses

Same change as ecosyste-ms/awesome#793, which took `cf-cache-status: BYPASS` to `HIT` at both APISIX and Cloudflare.